### PR TITLE
Fix: Invoke response hook when using a persistent session

### DIFF
--- a/behest/client.py
+++ b/behest/client.py
@@ -44,7 +44,9 @@ class HTTPClient(object):
         """
 
         if self._session:
-            return self._session.request(method=method, url=url, **kwargs)
+            r = self._session.request(method=method, url=url, **kwargs)
+            self._http_adapter.response_hook(r)
+            return r
 
         with requests.sessions.Session() as session:
             session.mount('https://', self._http_adapter)

--- a/test-requires
+++ b/test-requires
@@ -2,3 +2,4 @@ pip
 flake8
 httpretty
 tox-travis
+mock


### PR DESCRIPTION
This ensures the http_adapter's response_hook is called when using persistent session, same as occurs when using an non-persistent session.